### PR TITLE
add option to view expirations of reservations

### DIFF
--- a/ec2_costs/__init__.py
+++ b/ec2_costs/__init__.py
@@ -122,6 +122,8 @@ def _match_reserved_instances(reserved_groups, itype, in_vpc, zone, tenancy):
 
 
 def get_reserved_analysis(conn):
+    all_reserved_groups = get_reserved_groups(conn)
+    # duplicate the reserved_groups collection so we can destructively modify it when finding matches
     reserved_groups = get_reserved_groups(conn)
     instance_groups = get_instance_groups(conn)
 
@@ -148,4 +150,5 @@ def get_reserved_analysis(conn):
     return dict(
         instance_items=instance_items,
         not_used_reserved_instances=reserved_groups,
+        all_reserved_groups=all_reserved_groups,
     )


### PR DESCRIPTION
I tried to use the copy module but a shallow copy wasn't sufficient to preserve the reserved_groups collection and a deep copy bombed out.  The duplicate call is kind of gross though, and I just realized it happens every invocation rather than only when --show-expirations is provided...

Seems like this pushes things close to wanting to be broken out / refactored but I figured it would be useful for at least as a starting point so here it is.
